### PR TITLE
More setup instructions for newcomers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,29 @@ If you'd like to contribute code, open up a pull request. I'll review it, merge 
 
 There are two options for getting a version of the site running locally. In either case, get in touch if you'd like a data set to test against.
 
-In both cases it's important that the port match the one expected in the settings file (3000), so be sure to change that file if you're binding to another port.
+In both cases it's important that the port match the one expected in `config/settings.yml` (3000 by default), so be sure to change that file if you're binding to another port.
 
-You may also consider to change the Google Analytics code in the settings file as well.
+You may also consider to change the Google Analytics code in `config/settings.yml` as well.
 
 #### Direct Setup
 
-Before you begin, you will need to install [the Haskell platform](http://www.haskell.org/platform/). Cabal should have at least version 1.18 (to use sandboxes).
+##### Haskell Platform
+Before you begin, you will need to install [the Haskell platform](http://www.haskell.org/platform/). Cabal should have at least version 1.18 (to use sandboxes). You may have to update Cabal using Cabal and change the link to the newer version:
 
-You will need to make sure that the database specified in `config/` actually exists - either by installing Postgres and creating a database, or by changing the database settings to suit your local environment.
+```bash
+$ cabal update
+$ cabal install cabal cabal-install
+$ sudo mv /usr/bin/cabal /usr/bin/cabal-old
+$ sudo ln -s ~/.cabal/bin/cabal /usr/bin/
+```
 
-Then run:
+##### Database
+
+You will need to make sure that the database specified in `config/` actually exists - either by installing Postgres and creating a user and a database, or by changing the database settings to suit your local environment. Installing postgres for the first time can be challenging: you may want to edit `pg_hba.conf` after setting up your role (account) as superuser before you can use something like `createuser -d -r -p 5432 pi_base --password`, see the [postgresql documentation on database roles](http://www.postgresql.org/docs/9.3/static/database-roles.html). The password that is expected can be changed in `config/postgresql.yml`
+
+##### Initial initialization
+
+Initialize a Cabal sandbox, install pi-base and its dependencies and run a yesod development server (auto-reloading upon changes to the code) with:
 
 ```bash
 $ cabal sandbox init
@@ -30,7 +42,26 @@ $ cabal install
 $ yesod devel
 ```
 
-to install the dependencies to your local sandbox and then start dev-mode auto-reloading. Note that the first install may take a while.
+Note that the first install may take a while.
+
+##### Debugging
+
+For debugging, it can be helpful to empty the database. This can be achieved with the following:
+
+```bash
+$ dropdb pi_base_dev --port=5432 --username=pi_base
+$ createdb pi_base_dev --port=5432 --username=pi_base
+```
+
+##### Become admin in pi-base
+
+After you have logged in in the pi-base web application, you can promote yourself to an admin account (only) by manually editing the database. Assuming you have user id 1 in the database, you can do this with psql:
+
+```bash
+$ psql --username=pi_base --dbname=pi_base_dev -c "UPDATE remote_users SET admin = True WHERE id = 1;"
+```
+
+
 
 #### With Vagrant
 


### PR DESCRIPTION
1) Setting up a fresh copy of pi-base requires some knowledge about postgres; now it is much easier to get up to speed, as some typical commands are explained for creating an appropriate user and database.
2) Included a section how to become admin in pi-base.
3) Included a section on updating Cabal to the required version (that was still necessary on Ubuntu 14.04)
