### PR TITLE
add explicit authorization for POST on edit pages

### DIFF
--- a/Foundation.hs
+++ b/Foundation.hs
@@ -196,6 +196,10 @@ instance Yesod App where
     isAuthorized (EditPropertyR _) _ = isLoggedIn
     isAuthorized (EditTraitR    _) _ = isLoggedIn
     isAuthorized (EditTheoremR  _) _ = isLoggedIn
+    isAuthorized (SpaceR        _) _ = isLoggedIn
+    isAuthorized (PropertyR     _) _ = isLoggedIn
+    isAuthorized (TraitR        _) _ = isLoggedIn
+    isAuthorized (TheoremR      _) _ = isLoggedIn
 
     -- Must be an admin for any other write request
     isAuthorized _ True = isAdmin


### PR DESCRIPTION
Logged in users could see edit pages, but submitting would fail because POST goes to a different request. These are now explicitly authorized to be called by logged in users. Even if one later changes the authorizations for editing, it is better to state these ecplicitly.

Fixes #37
